### PR TITLE
Remove unwanted condition

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -280,8 +280,6 @@
         KIFTestWaitCondition(!isnan(tappablePointInElement.x), error, @"View is not tappable");
         [view longPressAtPoint:tappablePointInElement duration:duration];
         
-        KIFTestCondition(![view canBecomeFirstResponder] || [view isDescendantOfFirstResponder], error, @"Failed to make the view into the first responder");
-        
         return KIFTestStepResultSuccess;
     }];
     


### PR DESCRIPTION
Long press fails when element can't become first responder, not sure what is the purpose of this condition in the first place. I am removing it since it is getting in the way.

For https://github.com/Wattpad/ios/pull/9229

